### PR TITLE
Correct Type with Readline Package

### DIFF
--- a/rbenv/main.yml
+++ b/rbenv/main.yml
@@ -13,7 +13,7 @@
         - git
         - libcurl4-openssl-dev
         - libmysqlclient-dev
-        - libreadline5-dev
+        - libreadline-dev
         - libssl-dev
         - libxml2-dev
         - libxslt1-dev


### PR DESCRIPTION
Fixes

```
msg: No package matching 'libreadline5-dev' is available
```
